### PR TITLE
Improve weekday blocking with clear user messaging

### DIFF
--- a/app/routes/objednavka.tsx
+++ b/app/routes/objednavka.tsx
@@ -31,8 +31,19 @@ const isValidDeliveryDate = (
 		const today = startOfDay(new Date());
 		const minDate = addDays(today, 7);
 		const selectedDate = parseISO(dateString);
+		const dayOfWeek = selectedDate.getDay();
 
-		// Check if date is blocked
+		// Check if it's Sun-Wed (always blocked)
+		if (
+			dayOfWeek === 0 ||
+			dayOfWeek === 1 ||
+			dayOfWeek === 2 ||
+			dayOfWeek === 3
+		) {
+			return false;
+		}
+
+		// Check if date is manually blocked
 		if (blockedDates.includes(dateString)) {
 			return false;
 		}
@@ -158,6 +169,19 @@ export default function OrderForm() {
 			.refine(
 				(date) => isValidDeliveryDate(date, blockedDates),
 				(date) => {
+					const parsedDate = parseISO(date);
+					const dayOfWeek = parsedDate.getDay();
+
+					if (
+						dayOfWeek === 0 ||
+						dayOfWeek === 1 ||
+						dayOfWeek === 2 ||
+						dayOfWeek === 3
+					) {
+						return {
+							message: "Objednávky přijímáme pouze na čtvrtek, pátek a sobotu",
+						};
+					}
 					if (blockedDates.includes(date)) {
 						return { message: "Tento termín není dostupný" };
 					}
@@ -433,6 +457,9 @@ export default function OrderForm() {
 										/>
 										<p className="text-sm text-gray-500 mt-1">
 											Objednávky přijímáme minimálně 7 dní předem
+										</p>
+										<p className="text-sm text-orange-600 mt-1 font-medium">
+											⚠️ Objednávky přijímáme pouze na čtvrtek, pátek a sobotu
 										</p>
 										{errors.date && (
 											<p className="text-red-600 text-sm mt-1">

--- a/app/server/blocked-dates.server.ts
+++ b/app/server/blocked-dates.server.ts
@@ -1,4 +1,4 @@
-import { addMonths, isAfter, isBefore, parseISO } from "date-fns";
+import { parseISO } from "date-fns";
 import { desc, eq } from "drizzle-orm";
 import { blockedDates, db, users } from "../db";
 import type { BlockedDate } from "../db/schema";
@@ -53,17 +53,13 @@ export async function isDateBlocked(date: string): Promise<boolean> {
 	// Check if the date falls on Sunday (0), Monday (1), Tuesday (2), or Wednesday (3)
 	const parsedDate = parseISO(date);
 	const dayOfWeek = parsedDate.getDay();
-	const now = new Date();
-	const threeMonthsFromNow = addMonths(now, 3);
 
-	// Block Sundays, Mondays, Tuesdays, and Wednesdays (only within next 3 months)
+	// Block Sundays, Mondays, Tuesdays, and Wednesdays
 	if (
-		(dayOfWeek === 0 ||
-			dayOfWeek === 1 ||
-			dayOfWeek === 2 ||
-			dayOfWeek === 3) &&
-		isAfter(parsedDate, now) &&
-		isBefore(parsedDate, threeMonthsFromNow)
+		dayOfWeek === 0 ||
+		dayOfWeek === 1 ||
+		dayOfWeek === 2 ||
+		dayOfWeek === 3
 	) {
 		return true;
 	}

--- a/app/server/submit-order.server.ts
+++ b/app/server/submit-order.server.ts
@@ -144,6 +144,22 @@ export async function submitOrder(
 	// Check if the selected date is blocked
 	const dateIsBlocked = await isDateBlocked(orderData.date);
 	if (dateIsBlocked) {
+		const selectedDate = parseISO(orderData.date);
+		const dayOfWeek = selectedDate.getDay();
+
+		// Check if it's a weekday that's always blocked
+		if (
+			dayOfWeek === 0 ||
+			dayOfWeek === 1 ||
+			dayOfWeek === 2 ||
+			dayOfWeek === 3
+		) {
+			throw new Error(
+				"Objednávky přijímáme pouze na čtvrtek, pátek a sobotu. Neděle až středa jsou uzavřené.",
+			);
+		}
+
+		// Otherwise it's a manually blocked date
 		throw new Error("Vybraný termín není dostupný. Zvolte prosím jiný termín.");
 	}
 


### PR DESCRIPTION
## Summary
- Removed 3-month limit on weekday blocking (now blocks all Sun-Wed permanently)
- Added clear, specific error messages when users try to order on blocked weekdays
- Updated UI to show warning that orders are only accepted Thu-Sat

## Changes
- Modified `isDateBlocked` in `app/server/blocked-dates.server.ts` to remove time limit
- Updated error handling in `app/server/submit-order.server.ts` with specific weekday message
- Enhanced client-side validation in `app/routes/objednavka.tsx` with weekday checking
- Added warning message in date picker UI about Thu-Sat only availability

## User Experience
- Users now see: "⚠️ Objednávky přijímáme pouze na čtvrtek, pátek a sobotu" below the date picker
- When selecting Sun-Wed, they get: "Objednávky přijímáme pouze na čtvrtek, pátek a sobotu"
- Server-side validation provides same consistent messaging

## Test plan
- [ ] Try to select Sunday - should show error message
- [ ] Try to select Monday - should show error message  
- [ ] Try to select Tuesday - should show error message
- [ ] Try to select Wednesday - should show error message
- [ ] Try to select Thursday - should work
- [ ] Try to select Friday - should work
- [ ] Try to select Saturday - should work
- [ ] Verify warning message appears below date picker
- [ ] Test that manually blocked dates still work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)